### PR TITLE
Shift mailing to Postfix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ REACT_APP_PASSWORD_SALT_POSTFIX=Salt2
 DB_FORCE_TABLES_RECREATION=false
 NODE_ENV=development
 SECRET_KEY=SECRET
-USE_NODEMAILER='false'
-NODEMAILER_EMAIL=<sender_email_login>@gmail.com
-NODEMAILER_PWD=<sender_email_pwd>
+POSTFIX_ENABLED='true'
+POSTFIX_ADMINEMAIL=<your_personal_email>
+POSTFIX_RELAY=[<relay_smtp_domain>]:<relay_port>
+POSTFIX_EMAIL=<relay_account_login>@<relay_domain>
+POSTFIX_PASS=<relay_account_password>
+# Alternative:
+#POSTFIX_RELAY=
+#POSTFIX_EMAIL=desbordante@<your_domain>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,18 +67,35 @@ services:
       KAFKA_TOPIC_NAME: tasks
       MAX_THREADS_COUNT: 8
       SECRET_KEY: ${SECRET_KEY}
-      USE_NODEMAILER: ${USE_NODEMAILER}
-      NODEMAILER_EMAIL: ${NODEMAILER_EMAIL}
-      NODEMAILER_PWD: ${NODEMAILER_PWD}
-
+      POSTFIX_ENABLED: ${POSTFIX_ENABLED}
+      POSTFIX_HOST: postfix
+      POSTFIX_EMAIL: ${POSTFIX_EMAIL}
     ports:
       - "5000:5000"
     depends_on:
       - postgres
       - kafka
+      - postfix
     volumes:
       - uploads:/server/uploads/
       - datasets:/server/build/target/inputData/
+    networks:
+      - network
+    restart: always
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: 20m
+
+  postfix:
+    build:
+      context: ./web-app/
+      dockerfile: Dockerfile-postfix
+    environment:
+      POSTFIX_RELAY: ${POSTFIX_RELAY}
+      POSTFIX_EMAIL: ${POSTFIX_EMAIL}
+      POSTFIX_PASS: ${POSTFIX_PASS}
+      POSTFIX_ADMINEMAIL: ${POSTFIX_ADMINEMAIL}
     networks:
       - network
     restart: always

--- a/web-app/.dockerignore
+++ b/web-app/.dockerignore
@@ -4,6 +4,8 @@
 !setup.sh
 !Dockerfile-server
 !Dockerfile-client
+!Dockerfile-postfix
 !client
 !server
+!postfix
 */node_modules*

--- a/web-app/Dockerfile-postfix
+++ b/web-app/Dockerfile-postfix
@@ -6,17 +6,11 @@ FROM debian:bullseye-slim
 # pre config apt
 RUN echo "postfix postfix/main_mailer_type string Internet site" > preseed.txt && \
     echo "postfix postfix/mailname string desbordante.local" >> preseed.txt
-# load pre config for apt
+# load pre-config for apt
 RUN debconf-set-selections preseed.txt
 RUN apt-get -y update \
  && apt-get -y install postfix mailutils rsyslog \
  && apt-get -y install opendkim opendkim-tools
-
-### ################### ###
-### BASIC CONFIGURATION ###
-### ################### ###
-RUN postconf -e mynetworks="127.0.0.1 172.0.0.0/8"; \
-    postconf -e inet_protocols="ipv4"
 
 COPY postfix/ /postfix/
 WORKDIR /postfix/

--- a/web-app/Dockerfile-postfix
+++ b/web-app/Dockerfile-postfix
@@ -1,0 +1,23 @@
+FROM debian:bullseye-slim
+
+### ############ ###
+### INSTALLATION ###
+### ############ ###
+# pre config apt
+RUN echo "postfix postfix/main_mailer_type string Internet site" > preseed.txt && \
+    echo "postfix postfix/mailname string desbordante.local" >> preseed.txt
+# load pre config for apt
+RUN debconf-set-selections preseed.txt
+RUN apt-get -y update \
+ && apt-get -y install postfix mailutils rsyslog \
+ && apt-get -y install opendkim opendkim-tools
+
+### ################### ###
+### BASIC CONFIGURATION ###
+### ################### ###
+RUN postconf -e mynetworks="127.0.0.1 172.0.0.0/8"; \
+    postconf -e inet_protocols="ipv4"
+
+COPY postfix/ /postfix/
+WORKDIR /postfix/
+ENTRYPOINT ["./startup.sh"]

--- a/web-app/postfix/configure.sh
+++ b/web-app/postfix/configure.sh
@@ -6,6 +6,14 @@
 postconf -e inet_protocols="ipv4"
 # don't receive mail from the internet
 postconf -e mynetworks="127.0.0.1 172.0.0.0/8"
+# the min and max time between attempts to deliver a deferred message
+# default: 300s and 4000s
+postconf -e minimal_backoff_time="30s"
+postconf -e maximal_backoff_time="1h"
+# time between queue scans. Must be less or equal to minimal_backoff_time
+postconf -e queue_run_delay="30s"
+# the maximal time a message is queued before it is sent back as undeliverable
+postconf -e maximal_queue_lifetime="1d"
 
 ### ################## ###
 ### SITE CONFIGURATION ###

--- a/web-app/postfix/configure.sh
+++ b/web-app/postfix/configure.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+### ################## ###
+### SITE CONFIGURATION ###
+### ################## ###
+if [ -z "$POSTFIX_RELAY" ]; then
+    POSTFIX_DOMAIN=$(echo $POSTFIX_EMAIL | sed "s/.*@//")
+else
+    POSTFIX_DOMAIN="desbordante.local"
+fi
+echo $POSTFIX_DOMAIN > /etc/mailname
+# internet hostname of this server (SPF, DMARC, DKIM should be configured in the DNS)
+postconf -e myhostname="$POSTFIX_DOMAIN"
+# the list of domains that this machine considers itself the final destination for
+postconf -e mydestination="$POSTFIX_DOMAIN, $(hostname), localhost"
+# the domain that locally-posted mail appears to come from. The default is to append $myhostname
+postconf -e myorigin="/etc/mailname"
+# forward system mail outside
+sed -i "/root:.*/d" /etc/aliases
+echo "root: $POSTFIX_ADMINEMAIL" >> /etc/aliases
+newaliases
+
+if [ -z "$POSTFIX_RELAY" ]; then
+    ### ################## ###
+    ### DKIM CONFIGURATION ###
+    ### ################## ###
+    # generate DKIM keys. Remember to copy the public one into the DNS!
+    mkdir -m 750 /etc/opendkim && chown opendkim:opendkim /etc/opendkim
+    opendkim-genkey -D /etc/opendkim --domain=$POSTFIX_DOMAIN --selector=mail
+    echo "WARNING: add the following TXT entry into the DNS!" >> /etc/opendkim/reminder.txt
+    echo "Subdomain: mail._domainkey" >> /etc/opendkim/reminder.txt
+    echo "Text: $(cat /etc/opendkim/mail.txt | tr -d '\n' | sed 's/.*v=/v=/; s/[)].*//; s/\"//g; s/\s//g')" >> /etc/opendkim/reminder.txt
+    # configure opendkim
+    chown opendkim:opendkim /etc/opendkim/mail.private
+    chmod 600 /etc/opendkim/mail.private
+    cat > /etc/opendkim/TrustedHosts << EOF
+127.0.0.1
+localhost
+172.0.0.0/8
+$POSTFIX_DOMAIN
+$(hostname)
+EOF
+    cat > /etc/opendkim.conf << EOF
+SubDomains              Yes
+SendReports             Yes
+Canonicalization        simple/relaxed
+Mode                    s
+Syslog                  Yes
+SyslogSuccess           Yes
+LogWhy                  Yes
+KeyTable                /etc/opendkim/KeyTable
+SigningTable            refile:/etc/opendkim/SigningTable
+ExternalIgnoreList      refile:/etc/opendkim/TrustedHosts
+InternalHosts           refile:/etc/opendkim/TrustedHosts
+Socket                  inet:10021@localhost
+ReportAddress           "Desbordante Admin" <$POSTFIX_ADMINEMAIL>
+EOF
+    echo "mail._domainkey.$POSTFIX_DOMAIN $POSTFIX_DOMAIN:mail:/etc/opendkim/mail.private" > /etc/opendkim/KeyTable
+    echo "*@$POSTFIX_DOMAIN mail._domainkey.$POSTFIX_DOMAIN" > /etc/opendkim/SigningTable
+    # plug in opendkim into postfix; don't sign messages that bypass smtp (sent via terminal)
+    postconf -e milter_default_action="accept"
+    postconf -e smtpd_milters="inet:localhost:10021"
+else
+    ### ################### ###
+    ### RELAY CONFIGURATION ###
+    ### ################### ###
+    # don't try to deliver messages directly
+    postconf -e relayhost="$POSTFIX_RELAY"
+    # enable client-side authentication
+    postconf -e smtp_sasl_auth_enable="yes"
+    # location of username and password for the gateway
+    postconf -e smtp_sasl_password_maps="hash:/etc/postfix/sasl/sasl_passwd"
+    # disallow plain-text authentication
+    postconf -e smtp_sasl_security_options="noanonymous"
+    
+    POSTFIX_RELAYPORT=$(echo $POSTFIX_RELAY | sed "s/.*://")
+    if [ "$POSTFIX_RELAYPORT" = "587" ] || [ "$POSTFIX_RELAYPORT" = "465" ]; then
+        # enable STARTTLS encryption
+        postconf -e smtp_tls_security_level="encrypt"
+        # mandatory server certificate verification is appropriate if you only connect to servers that support RFC 2487
+        # if you deliver mail to the Internet, this shouldn't be a default policy
+        postconf -e smtp_tls_CAfile="/etc/ssl/certs/ca-certificates.crt"
+    fi
+
+    ### ################################ ###
+    ### SENDER CREDENTIALS CONFIGURATION ###
+    ### ################################ ###
+    echo "$POSTFIX_RELAY $POSTFIX_EMAIL:$POSTFIX_PASS" > /etc/postfix/sasl/sasl_passwd
+    postmap /etc/postfix/sasl/sasl_passwd
+    chown root:root /etc/postfix/sasl/sasl_passwd /etc/postfix/sasl/sasl_passwd.db
+    chmod 0600 /etc/postfix/sasl/sasl_passwd /etc/postfix/sasl/sasl_passwd.db
+fi
+
+# remind to configure DKIM in the DNS
+cat /etc/opendkim/reminder.txt >> /var/log/mail.log
+cat /etc/opendkim/reminder.txt | mail -r $POSTFIX_EMAIL -s "Please configure DKIM" $POSTFIX_ADMINEMAIL

--- a/web-app/postfix/startup.sh
+++ b/web-app/postfix/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -f "./configured" ]; then
-    echo "Desbordante-postfix started at $(date)" | mail -r $POSTFIX_EMAIL -s "Desbordante-postfix started" $POSTFIX_ADMINEMAIL
+    echo "Desbordante-postfix started at $(date) on the $HOSTNAME machine." | mail -r $POSTFIX_EMAIL -a "From: Desbordante <$POSTFIX_EMAIL>" -s "Desbordante-postfix started" $POSTFIX_ADMINEMAIL
 else 
     ./configure.sh
     touch ./configured

--- a/web-app/postfix/startup.sh
+++ b/web-app/postfix/startup.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+### ################## ###
+### SITE CONFIGURATION ###
+### ################## ###
+if [ -z "$POSTFIX_RELAY" ]; then
+    POSTFIX_DOMAIN=$(echo $POSTFIX_EMAIL | sed "s/.*@//")
+    echo $POSTFIX_DOMAIN > /etc/mailname
+else
+    POSTFIX_DOMAIN="desbordante.local"
+fi
+# internet hostname of this server (SPF, DMARC, DKIM should be configured in the DNS)
+postconf -e myhostname="$POSTFIX_DOMAIN"
+# the list of domains that this machine considers itself the final destination for
+postconf -e mydestination="$POSTFIX_DOMAIN, $(hostname), localhost"
+# the domain that locally-posted mail appears to come from. The default is to append $myhostname
+postconf -e myorigin="/etc/mailname"
+# forward system mail outside
+sed -i "/root:.*/d" /etc/aliases
+echo "root: $POSTFIX_ADMINEMAIL" >> /etc/aliases
+newaliases
+
+if [ -z "$POSTFIX_RELAY" ]; then
+    ### ################## ###
+    ### DKIM CONFIGURATION ###
+    ### ################## ###
+    # generate DKIM keys. Remember to copy the public one into the DNS!
+    mkdir -m 750 /etc/opendkim && chown opendkim:opendkim /etc/opendkim
+    opendkim-genkey -D /etc/opendkim --domain=$POSTFIX_DOMAIN --selector=mail
+    echo "WARNING: add the following TXT entry into the DNS!" >> /etc/opendkim/reminder.txt
+    echo "Subdomain: mail._domainkey" >> /etc/opendkim/reminder.txt
+    echo "Text: $(cat /etc/opendkim/mail.txt | tr -d '\n' | sed 's/.*v=/v=/; s/[)].*//; s/\"//g; s/\s//g')" >> /etc/opendkim/reminder.txt
+    # configure opendkim
+    chown opendkim:opendkim /etc/opendkim/mail.private
+    chmod 600 /etc/opendkim/mail.private
+    cat > /etc/opendkim/TrustedHosts << EOF
+127.0.0.1
+localhost
+172.0.0.0/8
+$POSTFIX_DOMAIN
+$(hostname)
+EOF
+    cat > /etc/opendkim.conf << EOF
+SubDomains              Yes
+SendReports             Yes
+Canonicalization        simple/relaxed
+Mode                    s
+Syslog                  Yes
+SyslogSuccess           Yes
+LogWhy                  Yes
+KeyTable                /etc/opendkim/KeyTable
+SigningTable            refile:/etc/opendkim/SigningTable
+ExternalIgnoreList      refile:/etc/opendkim/TrustedHosts
+InternalHosts           refile:/etc/opendkim/TrustedHosts
+Socket                  inet:10021@localhost
+ReportAddress           "Desbordante Admin" <$POSTFIX_ADMINEMAIL>
+EOF
+    echo "mail._domainkey.$POSTFIX_DOMAIN $POSTFIX_DOMAIN:mail:/etc/opendkim/mail.private" > /etc/opendkim/KeyTable
+    echo "*@$POSTFIX_DOMAIN mail._domainkey.$POSTFIX_DOMAIN" > /etc/opendkim/SigningTable
+    # plug in opendkim into postfix; don't sign messages that bypass smtp (sent via terminal)
+    postconf -e milter_default_action="accept"
+    postconf -e smtpd_milters="inet:localhost:10021"
+else
+    ### ################### ###
+    ### RELAY CONFIGURATION ###
+    ### #################### ###
+    # don't try to deliver messages directly
+    postconf -e relayhost="$POSTFIX_RELAY"
+    # enable client-side authentication
+    postconf -e smtp_sasl_auth_enable="yes"
+    # location of username and password for the gateway
+    postconf -e smtp_sasl_password_maps="hash:/etc/postfix/sasl/sasl_passwd"
+    # disallow plain-text authentication
+    postconf -e smtp_sasl_security_options="noanonymous"
+    
+    POSTFIX_RELAYPORT=$(echo $POSTFIX_RELAY | sed "s/.*://")
+    if [ "$POSTFIX_RELAYPORT" = "587" ] || [ "$POSTFIX_RELAYPORT" = "465" ]; then
+        # enable STARTTLS encryption
+        postconf -e smtp_tls_security_level="encrypt"
+        # mandatory server certificate verification is appropriate if you only connect to servers that support RFC 2487
+        # if you deliver mail to the Internet, this shouldn't be a default policy
+        postconf -e smtp_tls_CAfile="/etc/ssl/certs/ca-certificates.crt"
+    fi
+
+    ### ################################ ###
+    ### SENDER CREDENTIALS CONFIGURATION ###
+    ### ################################ ###
+    echo "$POSTFIX_RELAY $POSTFIX_EMAIL:$POSTFIX_PASS" > /etc/postfix/sasl/sasl_passwd
+    postmap /etc/postfix/sasl/sasl_passwd
+    chown root:root /etc/postfix/sasl/sasl_passwd /etc/postfix/sasl/sasl_passwd.db
+    chmod 0600 /etc/postfix/sasl/sasl_passwd /etc/postfix/sasl/sasl_passwd.db
+fi
+
+### ##### ###
+### START ###
+### ##### ###
+# don't read the kernel logs
+sed -i "/imklog/s/^/#/" /etc/rsyslog.conf
+touch /var/log/mail.log /var/log/mail.err /var/log/mail.warn
+chmod a+rw /var/log/mail.log
+service rsyslog start
+service postfix start
+# remind to configure DKIM in the DNS
+if [ -z "$POSTFIX_RELAY" ]; then
+    service opendkim start
+    cat /etc/opendkim/reminder.txt >> /var/log/mail.log
+    cat /etc/opendkim/reminder.txt | mail -r $POSTFIX_EMAIL -s "Please configure DKIM" $POSTFIX_ADMINEMAIL
+fi
+# follow the logs
+tail -F /var/log/mail.log

--- a/web-app/postfix/startup.sh
+++ b/web-app/postfix/startup.sh
@@ -1,110 +1,23 @@
 #!/bin/bash
 
-### ################## ###
-### SITE CONFIGURATION ###
-### ################## ###
-if [ -z "$POSTFIX_RELAY" ]; then
-    POSTFIX_DOMAIN=$(echo $POSTFIX_EMAIL | sed "s/.*@//")
-    echo $POSTFIX_DOMAIN > /etc/mailname
-else
-    POSTFIX_DOMAIN="desbordante.local"
-fi
-# internet hostname of this server (SPF, DMARC, DKIM should be configured in the DNS)
-postconf -e myhostname="$POSTFIX_DOMAIN"
-# the list of domains that this machine considers itself the final destination for
-postconf -e mydestination="$POSTFIX_DOMAIN, $(hostname), localhost"
-# the domain that locally-posted mail appears to come from. The default is to append $myhostname
-postconf -e myorigin="/etc/mailname"
-# forward system mail outside
-sed -i "/root:.*/d" /etc/aliases
-echo "root: $POSTFIX_ADMINEMAIL" >> /etc/aliases
-newaliases
-
-if [ -z "$POSTFIX_RELAY" ]; then
-    ### ################## ###
-    ### DKIM CONFIGURATION ###
-    ### ################## ###
-    # generate DKIM keys. Remember to copy the public one into the DNS!
-    mkdir -m 750 /etc/opendkim && chown opendkim:opendkim /etc/opendkim
-    opendkim-genkey -D /etc/opendkim --domain=$POSTFIX_DOMAIN --selector=mail
-    echo "WARNING: add the following TXT entry into the DNS!" >> /etc/opendkim/reminder.txt
-    echo "Subdomain: mail._domainkey" >> /etc/opendkim/reminder.txt
-    echo "Text: $(cat /etc/opendkim/mail.txt | tr -d '\n' | sed 's/.*v=/v=/; s/[)].*//; s/\"//g; s/\s//g')" >> /etc/opendkim/reminder.txt
-    # configure opendkim
-    chown opendkim:opendkim /etc/opendkim/mail.private
-    chmod 600 /etc/opendkim/mail.private
-    cat > /etc/opendkim/TrustedHosts << EOF
-127.0.0.1
-localhost
-172.0.0.0/8
-$POSTFIX_DOMAIN
-$(hostname)
-EOF
-    cat > /etc/opendkim.conf << EOF
-SubDomains              Yes
-SendReports             Yes
-Canonicalization        simple/relaxed
-Mode                    s
-Syslog                  Yes
-SyslogSuccess           Yes
-LogWhy                  Yes
-KeyTable                /etc/opendkim/KeyTable
-SigningTable            refile:/etc/opendkim/SigningTable
-ExternalIgnoreList      refile:/etc/opendkim/TrustedHosts
-InternalHosts           refile:/etc/opendkim/TrustedHosts
-Socket                  inet:10021@localhost
-ReportAddress           "Desbordante Admin" <$POSTFIX_ADMINEMAIL>
-EOF
-    echo "mail._domainkey.$POSTFIX_DOMAIN $POSTFIX_DOMAIN:mail:/etc/opendkim/mail.private" > /etc/opendkim/KeyTable
-    echo "*@$POSTFIX_DOMAIN mail._domainkey.$POSTFIX_DOMAIN" > /etc/opendkim/SigningTable
-    # plug in opendkim into postfix; don't sign messages that bypass smtp (sent via terminal)
-    postconf -e milter_default_action="accept"
-    postconf -e smtpd_milters="inet:localhost:10021"
-else
-    ### ################### ###
-    ### RELAY CONFIGURATION ###
-    ### #################### ###
-    # don't try to deliver messages directly
-    postconf -e relayhost="$POSTFIX_RELAY"
-    # enable client-side authentication
-    postconf -e smtp_sasl_auth_enable="yes"
-    # location of username and password for the gateway
-    postconf -e smtp_sasl_password_maps="hash:/etc/postfix/sasl/sasl_passwd"
-    # disallow plain-text authentication
-    postconf -e smtp_sasl_security_options="noanonymous"
-    
-    POSTFIX_RELAYPORT=$(echo $POSTFIX_RELAY | sed "s/.*://")
-    if [ "$POSTFIX_RELAYPORT" = "587" ] || [ "$POSTFIX_RELAYPORT" = "465" ]; then
-        # enable STARTTLS encryption
-        postconf -e smtp_tls_security_level="encrypt"
-        # mandatory server certificate verification is appropriate if you only connect to servers that support RFC 2487
-        # if you deliver mail to the Internet, this shouldn't be a default policy
-        postconf -e smtp_tls_CAfile="/etc/ssl/certs/ca-certificates.crt"
-    fi
-
-    ### ################################ ###
-    ### SENDER CREDENTIALS CONFIGURATION ###
-    ### ################################ ###
-    echo "$POSTFIX_RELAY $POSTFIX_EMAIL:$POSTFIX_PASS" > /etc/postfix/sasl/sasl_passwd
-    postmap /etc/postfix/sasl/sasl_passwd
-    chown root:root /etc/postfix/sasl/sasl_passwd /etc/postfix/sasl/sasl_passwd.db
-    chmod 0600 /etc/postfix/sasl/sasl_passwd /etc/postfix/sasl/sasl_passwd.db
+if [ -f "./configured" ]; then
+    echo "Desbordante-postfix started at $(date)" | mail -r $POSTFIX_EMAIL -s "Desbordante-postfix started" $POSTFIX_ADMINEMAIL
+else 
+    ./configure.sh
+    touch ./configured
+    # don't read the kernel logs
+    sed -i "/imklog/s/^/#/" /etc/rsyslog.conf
+    touch /var/log/mail.log /var/log/mail.err /var/log/mail.warn
+    chmod a+rw /var/log/mail.log
 fi
 
 ### ##### ###
 ### START ###
 ### ##### ###
-# don't read the kernel logs
-sed -i "/imklog/s/^/#/" /etc/rsyslog.conf
-touch /var/log/mail.log /var/log/mail.err /var/log/mail.warn
-chmod a+rw /var/log/mail.log
 service rsyslog start
 service postfix start
-# remind to configure DKIM in the DNS
 if [ -z "$POSTFIX_RELAY" ]; then
     service opendkim start
-    cat /etc/opendkim/reminder.txt >> /var/log/mail.log
-    cat /etc/opendkim/reminder.txt | mail -r $POSTFIX_EMAIL -s "Please configure DKIM" $POSTFIX_ADMINEMAIL
 fi
 # follow the logs
 tail -F /var/log/mail.log

--- a/web-app/server/src/graphql/schema/UserResolvers/emailSender.ts
+++ b/web-app/server/src/graphql/schema/UserResolvers/emailSender.ts
@@ -3,14 +3,9 @@ import { Code, CodeType } from "../../../db/models/UserInfo/Code";
 import { ApolloError } from "apollo-server-core";
 
 const transporter = nodemailer.createTransport({
-    host: "smtp.gmail.com",
-    port: 587,
-    secure: false,
-    requireTLS: true,
-    auth: {
-        user: process.env.NODEMAILER_EMAIL,
-        pass: process.env.NODEMAILER_PWD,
-    },
+    host: process.env.POSTFIX_HOST,
+    port: 25,
+    ignoreTLS: true,
 });
 
 export const sendVerificationCode = async (code: number, userEmail: string, type: CodeType) => {
@@ -19,13 +14,13 @@ export const sendVerificationCode = async (code: number, userEmail: string, type
     if (type === "EMAIL_VERIFICATION") {
         text = `Your email verification code is: ${code}`;
     } else if (type === "PASSWORD_RECOVERY_PENDING") {
-        text = `Your code for password recovery if : ${code}`;
+        text = `Your code for password recovery is : ${code}`;
     } else {
         throw new ApolloError("INTERNAL SERVER ERROR");
     }
 
     return await transporter.sendMail({
-        from: `Desbordante enjoyer <${process.env.NODEMAILER_EMAIL}>`,
+        from: `Desbordante Enjoyer <${process.env.POSTFIX_EMAIL}>`,
         to: userEmail,
         subject: "Email verification code",
         text,
@@ -36,7 +31,7 @@ export const createAndSendVerificationCode = async (
     userID: string, deviceID: string, userEmail: string, type: CodeType,
     logger?: typeof console.log) => {
     const code = await Code.createVerificationCode(userID, deviceID, type);
-    if (process.env.USE_NODEMAILER === "true") {
+    if (process.env.POSTFIX_ENABLED === "true") {
         try {
             await sendVerificationCode(code.value, userEmail, type);
         } catch (e) {
@@ -45,7 +40,7 @@ export const createAndSendVerificationCode = async (
         }
         logger && logger("Code was sent to email");
     } else {
-        logger && logger("Code wasn't sent to email [NODEMAILER DISABLED]");
+        logger && logger("Code wasn't sent to email [POSTFIX DISABLED]");
         logger && logger(`Issue new verification code = ${code.value}`);
     }
 };


### PR DESCRIPTION
## What's new

Nodemailer, bundled into the `desbordante-server`, now delegates email sending to `desbordante-postfix` container, which is configured independently.

## Motivation

This approach allows us to send (and auto-resend on failure) emails in non-blocking mode. And also, to change smtp-relays and email-addresses without the necessity to rebuild or restart `desbordante-server`.

## Postfix configuration

### As a standalone smtp-server

Emails may be sent directly from the server. In this case DNS records should be properly configured, otherwise they may be considered as spam. In the following example server's domain name is implied to be `desbordante.com` and its ip is `1.0.0.1`:

- A: `@ → 1.0.0.1`
- A: `mail → 1.0.0.1`
- MX: `@ → mail.desbordante.com`
- TXT/SPF: `@ → v=spf1 a mx ip4:1.0.0.1 -all`
- TXT/DMARC: `_dmarc → v=DMARC1; p=none`
- TXT/DKIM: will be sent to admin's email and duplicated to `desbordante-postfix`'s logs.

In this case, your `.env` file will additionally contain the following variables (please consider `.env.example`):

```env
POSTFIX_ENABLED='true'
POSTFIX_EMAIL=whatever@desbordante.com
POSTFIX_ADMINEMAIL=your@personal.email
```

### Using a relay

Alternatively, emails may be relayed through any smtp-relay with `AUTH LOGIN` or `AUTH PLAIN` enabled, such as `smtp.gmail.com` or `smtp.yandex.ru`. In this case, you'll need an existing account on that relay, and `.env` will contain the following if gmail is used:

```env
POSTFIX_ENABLED='true'
POSTFIX_RELAY=[smtp.gmail.com]:587
POSTFIX_EMAIL=your.existing.account@gmail.com
POSTFIX_PASS=application.password
POSTFIX_ADMINEMAIL=your@personal.email
```

Note:

> In Google, after the June 2022 one cannot log into applications using the main account password. So, having 2-step-verification enabled and some luck (so that it allows you to generate [application passwords](https://support.google.com/accounts/answer/185833)), you can set `POSTFIX_PASS=application.password`.

Sadly, `AUTH XOAUTH2` is [not supported](https://lists.andrew.cmu.edu/pipermail/cyrus-sasl/2018-May/003132.html) in `libsasl`, which is used as an authenticator in Postfix. Arguably, application passwords [are just as secure](http://mmogilvi.users.sourceforge.net/software/oauthbearer.html).