### PR TITLE
Fix MFD backend `approx` algo issue

### DIFF
--- a/web-app/server/src/graphql/schema/TaskInfo/resolvers.ts
+++ b/web-app/server/src/graphql/schema/TaskInfo/resolvers.ts
@@ -402,12 +402,8 @@ export const TaskInfoResolvers: Resolvers = {
         pieChartData: returnParent,
     },
     MFDTaskResult: {
-        result: async ({ prefix, state }) => {
-            const result = await state.getResultFieldAsBoolean(prefix, "result");
-            const data = await state.getResultFieldAsString(prefix, "deps");
-
-            return result || data.length == 0;
-        },
+        result: async ({ prefix, state }) =>
+            await state.getResultFieldAsBoolean(prefix, "result"),
     },
     FileFormat: {
         dataset: async ({ fileID }, obj, { models }) => {


### PR DESCRIPTION
Внезапно оказалось, что при использовании approx-алгоритма ожидается, что при возможном отрицательном результате ("метрика, вероятно, не держится") хайлайтов нет. Соответственно, убрал костыль

Мержить вместе с исправлением фронта от Сергея